### PR TITLE
Simplify function format of flimenu-imenu-separator

### DIFF
--- a/flimenu.el
+++ b/flimenu.el
@@ -127,7 +127,8 @@ hide the *Rescan* item."
       (dolist (item items (nreverse nitems))
         (push (cons (funcall flimenu-imenu-separator
                              (car item)
-                             (get-text-property 0 'flimenu--prefix-list (car item)))
+                             (nreverse
+                              (get-text-property 0 'flimenu--prefix-list (car item))))
                     (cdr item))
               nitems)))))
 

--- a/flimenu.el
+++ b/flimenu.el
@@ -127,15 +127,15 @@ hide the *Rescan* item."
         (setq index (delete rescan index)))))
   (let ((items (cl-mapcan 'flimenu-flatten-index-entry index))
         (nitems ()))
-    (if (not (functionp flimenu-imenu-separator))
-        items
-      (dolist (item items (nreverse nitems))
-        (push (cons (funcall flimenu-imenu-separator
-                             (car item)
-                             (nreverse
-                              (get-text-property 0 'flimenu--prefix-list (car item))))
-                    (cdr item))
-              nitems)))))
+    (if (functionp flimenu-imenu-separator)
+        (dolist (item items (nreverse nitems))
+          (push (cons (funcall flimenu-imenu-separator
+                               (car item)
+                               (nreverse
+                                (get-text-property 0 'flimenu--prefix-list (car item))))
+                      (cdr item))
+                nitems))
+      items)))
 
 (defun flimenu-make-current-imenu-index-flat ()
   (let ((original-imenu-function imenu-create-index-function))

--- a/flimenu.el
+++ b/flimenu.el
@@ -87,7 +87,8 @@ hide the *Rescan* item."
 (declare-function imenu--subalist-p "imenu")
 (cl-defun flimenu-flatten-index-entry (index-entry &optional (prefix "") plist)
   (cl-destructuring-bind (entry-name . rest) index-entry
-    (let ((new-entry-name (cond ((functionp flimenu-imenu-separator)
+    (let ((plist (copy-sequence plist))
+          (new-entry-name (cond ((functionp flimenu-imenu-separator)
                                  entry-name)
                                 (t
                                  (concat prefix entry-name))))
@@ -106,7 +107,11 @@ hide the *Rescan* item."
                                (flimenu-flatten-index-entry entry new-prefix plist))
                              rest)))
             (if entry-marker
-                (cons (cons new-entry-name entry-marker) flattened-subentries)
+                (progn
+                  (put-text-property
+                   0 1 'flimenu--prefix-list (cdr plist)
+                   new-entry-name)
+                  (cons (cons new-entry-name entry-marker) flattened-subentries))
               flattened-subentries))
         ;; Leaf Node
         (put-text-property

--- a/flimenu.el
+++ b/flimenu.el
@@ -84,6 +84,7 @@ hide the *Rescan* item."
 (defun flimenu-get-marker-from-string (string)
   (cl-find-if #'markerp (text-properties-at 0 string)))
 
+(declare-function imenu--subalist-p "imenu")
 (cl-defun flimenu-flatten-index-entry (index-entry &optional (prefix "") plist)
   (cl-destructuring-bind (entry-name . rest) index-entry
     (let ((new-entry-name (cond ((functionp flimenu-imenu-separator)
@@ -93,7 +94,7 @@ hide the *Rescan* item."
           (entry-marker
            (when flimenu-imenu-get-markers-from-entry-strings
              (flimenu-get-marker-from-string entry-name))))
-      (if (listp rest)
+      (if (imenu--subalist-p index-entry)
           ;; Internal Node
           (let* ((new-prefix (cond ((functionp flimenu-imenu-separator)
                                     (prog1 nil


### PR DESCRIPTION
I noticed my previous chosen function format for `flimenu-imenu-separator` was way to complicated because it was called during recursion and constructing the prefix/suffix was confusing this way for some purposes. (Sometimes you don't want to construct a string but attach text properties to it to show the path, for example when using [selectrum](https://github.com/raxod502/selectrum)).

With this PR the function receives the candidate name and the list of tree paths leading to this item as arguments and just needs to return the string to be displayed. The function now gets only called once for each item instead instead of getting called on each recursion level. I hope you don't mind changing the format, I guess so far nobody besides me used this recent feature anyway and the new format makes this feature far more accessible. Here is how I currently use it:

    (setq flimenu-imenu-separator #'flimenu-selectrum+)

    (defun flimenu-selectrum+ (name &optional ps)
      (when ps
        (put-text-property 
         0 1 'selectrum-candidate-display-suffix
         (propertize
          (concat
           " ("
           (mapconcat #'identity ps "/")
           ")")
          'face 'shadow)
         name))
      name)